### PR TITLE
fixed concatenation-priority-bug

### DIFF
--- a/src/Orderly/PayPalIpnBundle/Ipn.php
+++ b/src/Orderly/PayPalIpnBundle/Ipn.php
@@ -323,9 +323,10 @@ class Ipn
             for ($ii = 1, $count = 7; $ii < $count; $ii++)
             {
                 if(isset($this->ipnData['option_name'.$ii.'_'.$suffix]))
-                    $this->orderItems[$i]->setOptionName.$ii($this->ipnData['option_name'.$ii.'_'.$suffix]);
+                    $method = 'setOptionName' . $ii;
+                    $this->orderItems[$i]->$method($this->ipnData['option_name'.$ii.'_'.$suffix]);
                 if(isset($this->ipnData['option_selection'.$ii.'_'.$suffix]))
-                    $this->orderItems[$i]->setOptionSelection.$ii($this->ipnData['option_selection'.$ii.'_'.$suffix]);
+                    $this->orderItems[$i]->$method($this->ipnData['option_selection'.$ii.'_'.$suffix]);
             }
             
             //Updating dates


### PR DESCRIPTION
I didn't tried it with the original-code but in my little test-script
(below) with the IPN class, I got this error:

Notice: Undefined property: IpnOrderItems::$setOptionName in
/htdocs/test/index.php on line 739
Fatal error: Function name must be a string in /htdocs/test/index.php
on line 739

this should be line 326 in your class.

$i = 1;
$t = new IpnOrderItems();
echo $t->setOptionName.$i('test');
