### PR TITLE
Specified scale for fields with decimal type

### DIFF
--- a/src/Orderly/PayPalIpnBundle/Entity/IpnOrderItems.php
+++ b/src/Orderly/PayPalIpnBundle/Entity/IpnOrderItems.php
@@ -68,35 +68,35 @@ class IpnOrderItems
     /**
      * @var decimal $mcGross
      *
-     * @ORM\Column(name="mc_gross", type="decimal", nullable=true)
+     * @ORM\Column(name="mc_gross", type="decimal", scale=2, nullable=true)
      */
     private $mcGross;
 
     /**
      * @var decimal $mcHandling
      *
-     * @ORM\Column(name="mc_handling", type="decimal", nullable=true)
+     * @ORM\Column(name="mc_handling", type="decimal", scale=2, nullable=true)
      */
     private $mcHandling;
 
     /**
      * @var decimal $mcShipping
      *
-     * @ORM\Column(name="mc_shipping", type="decimal", nullable=true)
+     * @ORM\Column(name="mc_shipping", type="decimal", scale=2, nullable=true)
      */
     private $mcShipping;
 
     /**
      * @var decimal $tax
      *
-     * @ORM\Column(name="tax", type="decimal", nullable=true)
+     * @ORM\Column(name="tax", type="decimal", scale=2, nullable=true)
      */
     private $tax;
 
     /**
      * @var decimal $costPerItem
      *
-     * @ORM\Column(name="cost_per_item", type="decimal", nullable=true)
+     * @ORM\Column(name="cost_per_item", type="decimal", scale=2, nullable=true)
      */
     private $costPerItem;
 

--- a/src/Orderly/PayPalIpnBundle/Entity/IpnOrders.php
+++ b/src/Orderly/PayPalIpnBundle/Entity/IpnOrders.php
@@ -236,7 +236,7 @@ class IpnOrders
     /**
      * @var decimal $tax
      *
-     * @ORM\Column(name="tax", type="decimal", nullable=true)
+     * @ORM\Column(name="tax", type="decimal", scale=2, nullable=true)
      */
     private $tax;
 
@@ -334,7 +334,7 @@ class IpnOrders
     /**
      * @var decimal $shipping
      *
-     * @ORM\Column(name="shipping", type="decimal", nullable=true)
+     * @ORM\Column(name="shipping", type="decimal", scale=2, nullable=true)
      */
     private $shipping;
 
@@ -362,7 +362,7 @@ class IpnOrders
     /**
      * @var decimal $exchangeRate
      *
-     * @ORM\Column(name="exchange_rate", type="decimal", nullable=true)
+     * @ORM\Column(name="exchange_rate", type="decimal", scale=2, nullable=true)
      */
     private $exchangeRate;
 
@@ -376,49 +376,49 @@ class IpnOrders
     /**
      * @var decimal $mcFee
      *
-     * @ORM\Column(name="mc_fee", type="decimal", nullable=true)
+     * @ORM\Column(name="mc_fee", type="decimal", scale=2, nullable=true)
      */
     private $mcFee;
 
     /**
      * @var decimal $mcGross
      *
-     * @ORM\Column(name="mc_gross", type="decimal", nullable=true)
+     * @ORM\Column(name="mc_gross", type="decimal", scale=2, nullable=true)
      */
     private $mcGross;
 
     /**
      * @var decimal $mcHandling
      *
-     * @ORM\Column(name="mc_handling", type="decimal", nullable=true)
+     * @ORM\Column(name="mc_handling", type="decimal", scale=2, nullable=true)
      */
     private $mcHandling;
 
     /**
      * @var decimal $mcShipping
      *
-     * @ORM\Column(name="mc_shipping", type="decimal", nullable=true)
+     * @ORM\Column(name="mc_shipping", type="decimal", scale=2, nullable=true)
      */
     private $mcShipping;
 
     /**
      * @var decimal $paymentFee
      *
-     * @ORM\Column(name="payment_fee", type="decimal", nullable=true)
+     * @ORM\Column(name="payment_fee", type="decimal", scale=2, nullable=true)
      */
     private $paymentFee;
 
     /**
      * @var decimal $paymentGross
      *
-     * @ORM\Column(name="payment_gross", type="decimal", nullable=true)
+     * @ORM\Column(name="payment_gross", type="decimal", scale=2, nullable=true)
      */
     private $paymentGross;
 
     /**
      * @var decimal $settleAmount
      *
-     * @ORM\Column(name="settle_amount", type="decimal", nullable=true)
+     * @ORM\Column(name="settle_amount", type="decimal", scale=2, nullable=true)
      */
     private $settleAmount;
 
@@ -495,42 +495,42 @@ class IpnOrders
     /**
      * @var decimal $amount1
      *
-     * @ORM\Column(name="amount1", type="decimal", nullable=true)
+     * @ORM\Column(name="amount1", type="decimal", scale=2, nullable=true)
      */
     private $amount1;
 
     /**
      * @var decimal $amount2
      *
-     * @ORM\Column(name="amount2", type="decimal", nullable=true)
+     * @ORM\Column(name="amount2", type="decimal", scale=2, nullable=true)
      */
     private $amount2;
 
     /**
      * @var decimal $amount3
      *
-     * @ORM\Column(name="amount3", type="decimal", nullable=true)
+     * @ORM\Column(name="amount3", type="decimal", scale=2, nullable=true)
      */
     private $amount3;
 
     /**
      * @var decimal $mcAmount1
      *
-     * @ORM\Column(name="mc_amount1", type="decimal", nullable=true)
+     * @ORM\Column(name="mc_amount1", type="decimal", scale=2, nullable=true)
      */
     private $mcAmount1;
 
     /**
      * @var decimal $mcAmount2
      *
-     * @ORM\Column(name="mc_amount2", type="decimal", nullable=true)
+     * @ORM\Column(name="mc_amount2", type="decimal", scale=2, nullable=true)
      */
     private $mcAmount2;
 
     /**
      * @var decimal $mcAmount3
      *
-     * @ORM\Column(name="mc_amount3", type="decimal", nullable=true)
+     * @ORM\Column(name="mc_amount3", type="decimal", scale=2, nullable=true)
      */
     private $mcAmount3;
 
@@ -614,14 +614,14 @@ class IpnOrders
     /**
      * @var decimal $discount
      *
-     * @ORM\Column(name="discount", type="decimal", nullable=true)
+     * @ORM\Column(name="discount", type="decimal", scale=2, nullable=true)
      */
     private $discount;
 
     /**
      * @var decimal $shippingDiscount
      *
-     * @ORM\Column(name="shipping_discount", type="decimal", nullable=true)
+     * @ORM\Column(name="shipping_discount", type="decimal", scale=2, nullable=true)
      */
     private $shippingDiscount;
 

--- a/src/Orderly/PayPalIpnBundle/Resources/config/doctrine/metadata/orm/IpnOrderItems.orm.yml
+++ b/src/Orderly/PayPalIpnBundle/Resources/config/doctrine/metadata/orm/IpnOrderItems.orm.yml
@@ -33,21 +33,26 @@ IpnOrderItems:
       nullable: true
     mcGross:
       type: decimal
+      scale: 2
       nullable: true
       column: mc_gross
     mcHandling:
       type: decimal
+      scale: 2
       nullable: true
       column: mc_handling
     mcShipping:
       type: decimal
+      scale: 2
       nullable: true
       column: mc_shipping
     tax:
       type: decimal
+      scale: 2
       nullable: true
     costPerItem:
       type: decimal
+      scale: 2
       nullable: true
       column: cost_per_item
     optionName1:

--- a/src/Orderly/PayPalIpnBundle/Resources/config/doctrine/metadata/orm/IpnOrders.orm.yml
+++ b/src/Orderly/PayPalIpnBundle/Resources/config/doctrine/metadata/orm/IpnOrders.orm.yml
@@ -173,6 +173,7 @@ IpnOrders:
       nullable: true
     tax:
       type: decimal
+      scale: 2
       nullable: true
     authId:
       type: string
@@ -251,6 +252,7 @@ IpnOrders:
       column: shipping_method
     shipping:
       type: decimal
+      scale: 2
       nullable: true
     transactionEntity:
       type: string
@@ -272,6 +274,7 @@ IpnOrders:
       column: txn_type
     exchangeRate:
       type: decimal
+      scale: 2
       nullable: true
       column: exchange_rate
     mcCurrency:
@@ -282,30 +285,37 @@ IpnOrders:
       column: mc_currency
     mcFee:
       type: decimal
+      scale: 2
       nullable: true
       column: mc_fee
     mcGross:
       type: decimal
+      scale: 2
       nullable: true
       column: mc_gross
     mcHandling:
       type: decimal
+      scale: 2
       nullable: true
       column: mc_handling
     mcShipping:
       type: decimal
+      scale: 2
       nullable: true
       column: mc_shipping
     paymentFee:
       type: decimal
+      scale: 2
       nullable: true
       column: payment_fee
     paymentGross:
       type: decimal
+      scale: 2
       nullable: true
       column: payment_gross
     settleAmount:
       type: decimal
+      scale: 2
       nullable: true
       column: settle_amount
     settleCurrency:
@@ -366,23 +376,29 @@ IpnOrders:
       nullable: true
     amount1:
       type: decimal
+      scale: 2
       nullable: true
     amount2:
       type: decimal
+      scale: 2
       nullable: true
     amount3:
       type: decimal
+      scale: 2
       nullable: true
     mcAmount1:
       type: decimal
+      scale: 2
       nullable: true
       column: mc_amount1
     mcAmount2:
       type: decimal
+      scale: 2
       nullable: true
       column: mc_amount2
     mcAmount3:
       type: decimal
+      scale: 2
       nullable: true
       column: mc_amount3
     recurring:
@@ -446,9 +462,11 @@ IpnOrders:
       column: order_status
     discount:
       type: decimal
+      scale: 2
       nullable: true
     shippingDiscount:
       type: decimal
+      scale: 2
       nullable: true
       column: shipping_discount
     ipnTrackId:


### PR DESCRIPTION
This pull request fixes issue of decimal scale setting to `0` rather than `2`, when updating schema with `doctrine:schema:update`.
Issue: https://github.com/orderly/symfony2-paypal-ipn/issues/3
