### PR TITLE
Fix Symfony version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/symfony" : "2.0.12"
+        "symfony/symfony" : ">=2.0.12"
     },
     "autoload": {
         "psr-0": { "Orderly\\PayPalIpnBundle": "" }


### PR DESCRIPTION
Updated Symfony version in composer.json, so that >=2.0.12 can be used
