### PR TITLE
Fix composer autoload config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "symfony/symfony" : ">=2.0.12"
     },
     "autoload": {
-        "psr-0": { "Orderly\\PayPalIpnBundle": "" }
-    },
-    "target-dir": "Orderly\\PayPalIpnBundle"
+        "psr-0": { "Orderly\\PayPalIpnBundle": "src" }
+    }
 }


### PR DESCRIPTION
With target-dir option composer installs source into `vendor/orderly/paypal-ipn-bundle/Orderly\\PayPalIpnBundle/` and autoload is not working.
I removed target-dir and specified `src` folder to autoload classes.
