### PR TITLE
Handle refunded messages

### DIFF
--- a/src/Orderly/PayPalIpnBundle/Ipn.php
+++ b/src/Orderly/PayPalIpnBundle/Ipn.php
@@ -86,6 +86,7 @@ class Ipn
     const PAID = 'PAID';
     const WAITING = 'WAITING';
     const REJECTED = 'REJECTED';
+    const REFUNDED = 'REFUNDED';
 
     /** The constructor. Loads the helpers and configuration files, sets the configuration constants
      *
@@ -239,6 +240,9 @@ class Ipn
             case "Expired": // Credit card company didn't recognise card
             case "Reversed": // Credit card holder has got the credit card co to reverse the charge
                 $this->orderStatus = self::REJECTED;
+                break;
+            case "Refunded":
+                $this->orderStatus = self::REFUNDED;
                 break;
             default:
                 $this->_logTransaction('IPN', 'ERROR', 'Payment status of ' . $this->ipnData['payment_status'] . ' is not recognised', $ipnResponse);


### PR DESCRIPTION
Hi,

when you issue a refund for a order, the status of this refund is not tracked correct and applied to that order. Enclosed is a example message from my sandbox test:

```
{
...
    "created_at" : ISODate("2013-02-20T17:32:16Z"),
    "detail" : "{\"ipn_data\":{\"mc_gross\":\"-30.00\",\"protection_eligibility\":\"Eligible\",\"payer_id\":\"NK8X5HG84S76A\",\"address_street\":\"1 Main St\",\"payment_date\":\"09:26:40 Feb 20, 2013 PST\",\"payment_status\":\"Refunded\",\"charset\":\"windows-1252\",\"address_zip\":\"95131\",\"first_name\":\"Alexander\",\"mc_fee\":\"-0.87\",\"address_country_code\":\"US\",\"address_name\":\"Alexander Pirsig\",\"notify_version\":\"3.7\",\"reason_code\":\"other\",\"custom\":null,\"address_country\":\"United States\",\"address_city\":\"San Jose\",\"verify_sign\":\"AcY-2f5guIkbbOFIfCTzcMZD8nX6AgQej2qxZikiDFo9-Sic1ugX2RB7\",\"payer_email\":\"alex_1361379076_per@pirsig.net\",\"parent_txn_id\":\"1F137554MV413364H\",\"txn_id\":\"1VP60615CN1665624\",\"payment_type\":\"instant\",\"last_name\":\"Pirsig\",\"address_state\":\"CA\",\"receiver_email\":\"alex_1361369781_biz@xxx.com\",\"payment_fee\":\"-0.87\",\"receiver_id\":\"49DJ69A4PH9SJ\",\"item_name\":null,\"mc_currency\":\"USD\",\"item_number\":null,\"residence_country\":\"US\",\"test_ipn\":\"1\",\"handling_amount\":\"0.00\",\"transaction_subject\":null,\"payment_gross\":\"-30.00\",\"shipping\":\"0.00\",\"ipn_track_id\":\"755046e86145e\"},\"ipn_response\":\"HTTP\\/1.1 200 OK\\r\\nDate: Wed, 20 Feb 2013 17:32:16 GMT\\r\\nServer: Apache\\r\\nX-Frame-Options: SAMEORIGIN\\r\\nSet-Cookie: c9MWDuvPtT9GIMyPc3jwol1VSlO=9BlDcwfGGLTUkf_QlkNWYprhnczWY8MqZvC3Njm4rLqGDoTd2dFiytXcqjDKXob0_DSCKPyl1iIkw1CeZZfM0JHvy-R12lGWW5Ygpme3AUGLwP_e8KX6_M6mm8k-c0LVYpi2DW%7cp98emVmn5MBAoEa544sG2BwwVMv3ZHxzhAhu19spEtsqRd7FO0MridFDsc3sd90Bic0lh0%7cUxTyUU-fuib3ArkmWFhMANhK46XXdqn8JU_vhJerfgrZunWD10vFKSBj7AgkQIHBB-bki0%7c1361381537; domain=.paypal.com; path=\\/; Secure; HttpOnly\\r\\nSet-Cookie: cookie_check=yes; expires=Sat, 18-Feb-2023 17:32:17 GMT; domain=.paypal.com; path=\\/; Secure; HttpOnly\\r\\nSet-Cookie: navcmd=_notify-validate; domain=.paypal.com; path=\\/; Secure; HttpOnly\\r\\nSet-Cookie: navlns=0.0; expires=Tue, 15-Feb-2033 17:32:17 GMT; domain=.paypal.com; path=\\/; Secure; HttpOnly\\r\\nSet-Cookie: Apache=10.72.109.11.1361381536967200; path=\\/; expires=Fri, 13-Feb-43 17:32:16 GMT\\r\\nConnection: close\\r\\nTransfer-Encoding: chunked\\r\\nContent-Type: text\\/html; charset=UTF-8\\r\\n\\r\\n8\\r\\nVERIFIED\\r\\n0\\r\\n\\r\\n\"}",
    "ipn_data_hash" : "ed37ecd972d3061c3331b98690c0120d",
    "listener_name" : "IPN",
    "message" : "Payment status of Refunded is not recognised",
    "status" : "ERROR",
    "transaction_id" : "1VP60615CN1665624",
    "updated_at" : ISODate("2013-02-20T17:32:18Z")
}
```
