### PR TITLE
Remove deprecated call getEntityManager to getManager

### DIFF
--- a/src/Orderly/PayPalIpnBundle/OrderlyPayPalIpnBundle.php
+++ b/src/Orderly/PayPalIpnBundle/OrderlyPayPalIpnBundle.php
@@ -29,7 +29,7 @@ class OrderlyPayPalIpnBundle extends Bundle
     {      
         if (!\Doctrine\DBAL\Types\Type::hasType('enumorderstatus')){
             \Doctrine\DBAL\Types\Type::addType('enumorderstatus', 'Orderly\PayPalIpnBundle\Types\EnumOrderStatus');
-            $em = $this->container->get('doctrine')->getEntityManager();
+            $em = $this->container->get('doctrine')->getManager();
             $em->getConnection()->getDatabasePlatform()->registerDoctrineTypeMapping('enumorderstatus', 'string');
         }
     }


### PR DESCRIPTION
Use getManager() instead of getEntityManager() that is deprecated since symfony 2.1
