### PR TITLE
Detect and log subscription signup notifications

### DIFF
--- a/src/Orderly/PayPalIpnBundle/Ipn.php
+++ b/src/Orderly/PayPalIpnBundle/Ipn.php
@@ -220,6 +220,13 @@ class Ipn
             
             return FALSE;
         }
+        
+        //Check if IPN is an subscription signup notification
+        // because subscription signups don't have a payment_status
+        if (isset($this->ipnData['txn_type']) && $this->ipnData['txn_type'] == 'subscr_signup'){
+            $this->_logTransaction('IPN', 'SUCCESS', 'Subscription has been created', $ipnResponse);
+            return true;
+        }
 
         // The final check is of the payment status. We need to surface this
         // as a class variable so that the calling code can decide how to respond.


### PR DESCRIPTION
Instead of generating an invalid error, this detect an subscription signup which is generated by the first subscription payment.
