### PR TITLE
Introduce NOTPAID constant

### DIFF
--- a/src/Orderly/PayPalIpnBundle/Ipn.php
+++ b/src/Orderly/PayPalIpnBundle/Ipn.php
@@ -66,7 +66,7 @@ class Ipn
     private $ipnData = array(); // Contains the POST values for IPN
     private $order = null; // Contains the fields pertaining to an order
     private $orderItems = array(); // Contains the order items within an order
-    private $orderStatus; // All-important variable: whether the order has been paid for yet or not
+    private $orderStatus = self::NOTPAID; // All-important variable: whether the order has been paid for yet or not
 
     // Configuration constants
     private $isLive; // The flag used to indicate we are operating in the live environment
@@ -81,6 +81,7 @@ class Ipn
     private $objectManager; // Object Manger holding reference to DB-Driver
 
     // Payment status constants we use, more user-friendly than the PayPal ones
+    const NOTPAID = 'NOTPAID';
     const PAID = 'PAID';
     const WAITING = 'WAITING';
     const REJECTED = 'REJECTED';


### PR DESCRIPTION
It would be nice if there is a actual "NOTPAID" order status in the IPN Class. The reason for this is, that I´m using the IPN class payment states in a different ODM Document to track shopping cart dropouts. When a user decides to start a payment I generate a order document with a global order status. The initial state is therefore "IPN::NOTPAID". When the user drops out I have his data and generate a followup. If the payment later gets confirmed I change this to IPN::PAID and so on ...

Also I think filling the orderStatus with an initial state is better than testing for orderStatus != null
