### PR TITLE
Fix option_name and option_selection

### DIFF
--- a/src/Orderly/PayPalIpnBundle/Ipn.php
+++ b/src/Orderly/PayPalIpnBundle/Ipn.php
@@ -339,13 +339,13 @@ class Ipn
             // Reference: https://cms.paypal.com/us/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_html_Appx_websitestandard_htmlvariables
             for ($ii = 1, $count = 7; $ii < $count; $ii++)
             {
-                if(isset($this->ipnData['option_name'.$ii.'_'.$suffix])) {
+                if(isset($this->ipnData['option_name'.$ii.$suffixUnderscore])) {
                     $method = 'setOptionName' . $ii;
-                    $this->orderItems[$i]->$method($this->ipnData['option_name'.$ii.'_'.$suffix]);
+                    $this->orderItems[$i]->$method($this->ipnData['option_name'.$ii.$suffixUnderscore]);
                 }
-                if(isset($this->ipnData['option_selection'.$ii.'_'.$suffix])) {
+                if(isset($this->ipnData['option_selection'.$ii.$suffixUnderscore])) {
                     $method = 'setOptionSelection' . $ii;
-                    $this->orderItems[$i]->$method($this->ipnData['option_selection'.$ii.'_'.$suffix]);
+                    $this->orderItems[$i]->$method($this->ipnData['option_selection'.$ii.$suffixUnderscore]);
                 }
             }
             


### PR DESCRIPTION
When a PayPal button had a product options dropdown, the option_name and option_selection values weren't passed right.

'option_name'.$ii.'_'.$suffix was resolved to "option_name1_" instead of the expected "option_name1".

Changing '_'.$suffix to $suffixUnderscore fixes this issue.
