### PR TITLE
Fixes #30. Validate Paypal response properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All pre-payment functionality (e.g. posting the checkout information to PayPal) 
 
 ## Dependencies
 
-The Symfony PayPal IPN Bundle depends on [Symfony2] [symfony2] and [Doctrine 2.0] [doctrine2.0].
+The Symfony PayPal IPN Bundle depends on [Symfony2] [symfony2], [Doctrine 2.0] [doctrine2.0], and curl.
 
 An example order confirmation email which uses the [Twig] [twig] templating language is also provided. 
 
@@ -136,12 +136,14 @@ orderly_pay_pal_ipn:
     # Constants for the live environment (default settings in Configuration.php)
     email:   sales@CHANGEME.com
     url:     https://www.paypal.com/cgi-bin/webscr
+    proxy:   ~
     debug:   %kernel.debug%
 
     # Constants for the sandbox environment (default settings in Configuration.php)
     sandbox_email:   system_CHANGEME_biz@CHANGEME.com
     sandbox_url:     https://www.sandbox.paypal.com/cgi-bin/webscr
     sandbox_debug:   true
+    sandbox_proxy:    ~
 
     drivers:
         orm:
@@ -167,12 +169,14 @@ orderly_pay_pal_ipn:
     # Constants for the live environment (default settings in Configuration.php)
     email:   sales@CHANGEME.com
     url:     https://www.paypal.com/cgi-bin/webscr
+    proxy:   ~
     debug:   %kernel.debug%
 
     # Constants for the sandbox environment (default settings in Configuration.php)
     sandbox_email:   system_CHANGEME_biz@CHANGEME.com
     sandbox_url:     https://www.sandbox.paypal.com/cgi-bin/webscr
     sandbox_debug:   true
+    sandbox_proxy:    ~
 
     drivers:
         odm:
@@ -293,12 +297,14 @@ orderly_pay_pal_ipn:
     # Constants for the live environment (default settings in Configuration.php)
     email:   sales@CHANGEME.com
     url:     https://www.paypal.com/cgi-bin/webscr
+    proxy:   ~
     debug:   %kernel.debug%
 
     # Constants for the sandbox environment (default settings in Configuration.php)
     sandbox_email:   system_CHANGEME_biz@CHANGEME.com
     sandbox_url:     https://www.sandbox.paypal.com/cgi-bin/webscr
     sandbox_debug:   true
+    sandbox_proxy:    ~
 
     drivers: # Define one driver only.
         orm:

--- a/src/Orderly/PayPalIpnBundle/DependencyInjection/Configuration.php
+++ b/src/Orderly/PayPalIpnBundle/DependencyInjection/Configuration.php
@@ -37,10 +37,12 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('islive')->defaultValue(true)->end()
                 ->scalarNode('email')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('url')->defaultValue('https://www.paypal.com/cgi-bin/webscr')->end()
+                ->scalarNode('proxy')->defaultValue(null)->end()
                 ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
                 ->scalarNode('sandbox_email')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('sandbox_url')->defaultValue('https://www.sandbox.paypal.com/cgi-bin/webscr')->end()
                 ->booleanNode('sandbox_debug')->defaultValue(true)->end()
+                ->scalarNode('sandbox_proxy')->defaultValue(null)->end()
             ->end()
         ->end();
 

--- a/src/Orderly/PayPalIpnBundle/DependencyInjection/OrderlyPayPalIpnExtension.php
+++ b/src/Orderly/PayPalIpnBundle/DependencyInjection/OrderlyPayPalIpnExtension.php
@@ -46,12 +46,14 @@ class OrderlyPayPalIpnExtension extends Extension
             $container->setParameter('orderly.paypalipn.email', $config['email']);
             $container->setParameter('orderly.paypalipn.url', $config['url']);
             $container->setParameter('orderly.paypalipn.debug', $config['debug']);
+            $container->setParameter('orderly.paypalipn.proxy', $config['proxy']);
         }
         else
         {
             $container->setParameter('orderly.paypalipn.email', $config['sandbox_email']);
             $container->setParameter('orderly.paypalipn.url', $config['sandbox_url']);
             $container->setParameter('orderly.paypalipn.debug', $config['sandbox_debug']);
+            $container->setParameter('orderly.paypalipn.proxy', $config['sandbox_proxy']);
         }
 
         $driver = null;


### PR DESCRIPTION
fsockopen can lead to chunked response. This can lead to read incorrectly Paypal's response.
Changed fsockopen for curl.
Introducing proxy in order to talk to Paypal.
