### PR TITLE
We only add \r\n when Paypal sends us a vanilla \n

### DIFF
--- a/src/Orderly/PayPalIpnBundle/Ipn.php
+++ b/src/Orderly/PayPalIpnBundle/Ipn.php
@@ -173,8 +173,10 @@ class Ipn
         foreach (array_keys($ipnDataRaw) as $field) {
             if (!$usingCache) {
                 $value = $request->request->get($field);
-                // Put line feeds back to \r\n for PayPal otherwise multi-line data will be rejected as INVALID
-                $ipnDataRaw[$field] = str_replace("\n", "\r\n", $value);
+                if(strpos($value, "\r\n") === false){
+                    // Put line feeds back to \r\n for PayPal otherwise multi-line data will be rejected as INVALID
+                    $ipnDataRaw[$field] = str_replace("\n", "\r\n", $value);
+                }
             }
 
             // Let's also store this in this class, turning empty strings back to null to avoid breaking Doctrine later


### PR DESCRIPTION
Paypal is sending \r\n on our website. With the current code, \n are replaced by \r\n all the time, resulting in \r\r\n. This gives us an INVALID IPN response, even when it was valid. By adding a check to make sure Paypal is sending vanilla \n before replacing it with a \r\n, we solved this bug once and for all.

Closes #36 
