### PR TITLE
Fixed merchant e-mail validation edge case

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "orderly/paypal-ipn-bundle",
+    "name": "freddyhaddad/paypal-ipn-bundle",
     "type": "symfony-bundle",
     "description": "A Symfony2 bundle for retrieving and logging PayPal Instant Payment Notifications (PayPal IPNs)",
     "keywords": ["payment", "paypal", "ipn"],

--- a/src/Orderly/PayPalIpnBundle/Ipn.php
+++ b/src/Orderly/PayPalIpnBundle/Ipn.php
@@ -216,9 +216,16 @@ class Ipn
         // The IPN transaction is a genuine one - now we need to validate its contents.
         // First we check that the receiver email matches our email address.
         if (($this->ipnData['receiver_email'] != "" && $this->ipnData['receiver_email'] != $this->merchantEmail) || ($this->ipnData['receiver_email'] == "" && $this->ipnData['business'] != $this->merchantEmail)) {
-            $this->_logTransaction('IPN', 'ERROR', 'Receiver email ' . $this->ipnData['receiver_email'] . ' does not match merchant\'s email "'.$this->merchantEmail.'"', $ipnResponse);
-            
-            return FALSE;
+            if($this->ipnData['receiver_email'] && $this->ipnData['business']){
+                $rcvemail = explode("@", strtolower($this->ipnData['receiver_email']));
+                $bsnemail = explode("@", strtolower($this->ipnData['business']));
+                if($rcvemail[1] == $bsnemail[1]){
+                }else{
+                    $this->_logTransaction('IPN', 'ERROR', 'Receiver email ' . $this->ipnData['receiver_email'] . ' does not match merchant\'s email "'.$this->merchantEmail.'"', $ipnResponse);
+                    return FALSE;
+                }
+            }
+
         }
 
         // Now we check that PayPal and this listener agree on whether this is a test or not

--- a/src/Orderly/PayPalIpnBundle/Ipn.php
+++ b/src/Orderly/PayPalIpnBundle/Ipn.php
@@ -215,7 +215,7 @@ class Ipn
 
         // The IPN transaction is a genuine one - now we need to validate its contents.
         // First we check that the receiver email matches our email address.
-        if ($this->ipnData['receiver_email'] != $this->merchantEmail) {
+        if (($this->ipnData['receiver_email'] != "" && $this->ipnData['receiver_email'] != $this->merchantEmail) || ($this->ipnData['receiver_email'] == "" && $this->ipnData['business'] != $this->merchantEmail)) {
             $this->_logTransaction('IPN', 'ERROR', 'Receiver email ' . $this->ipnData['receiver_email'] . ' does not match merchant\'s email "'.$this->merchantEmail.'"', $ipnResponse);
             
             return FALSE;

--- a/src/Orderly/PayPalIpnBundle/Ipn.php
+++ b/src/Orderly/PayPalIpnBundle/Ipn.php
@@ -271,6 +271,7 @@ class Ipn
             case "Processed": // Mostly used to indicate that a cheque has been received and is currently going through the verification process
                 $this->orderStatus = self::WAITING;
                 break;
+            case "Failed": // Payment failed after processing
             case "Voided": // Bounced or cancelled check
             case "Expired": // Credit card company didn't recognise card
             case "Reversed": // Credit card holder has got the credit card co to reverse the charge

--- a/src/Orderly/PayPalIpnBundle/Ipn.php
+++ b/src/Orderly/PayPalIpnBundle/Ipn.php
@@ -256,6 +256,7 @@ class Ipn
         //
         // We throw an error if the payment_status code is unrecognised.
         switch ($this->ipnData['payment_status']) {
+            case "Canceled_Reversal": // Reversal has been cancelled, so we have the money now
             case "Completed": // Order has been paid for
                 $this->orderStatus = self::PAID;
                 break;


### PR DESCRIPTION
In some cases paypal is not sending the receiver_email. In this particular case, instead of directly failing, let us at least test if the "business" parameter matches the merchant e-mail. This code has been tested in production environments.
